### PR TITLE
typo hunter

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -47,11 +47,10 @@ To create a reproducible research compendium using the rrtools approach, follow 
 
 - this gives MIT licence in DESCRIPTION, adds LICENSE file with our name in it
 
-#### 3. `devtools::use_github(".", auth_token = "xxxx")`         
+#### 3. `devtools::use_github(".", auth_token = "xxxx", private = FALSE)`
 
 - This will initialize a local git repository, and connect to github.com and create a remote repository there. 
 - we need to get a token from <https://github.com/settings/tokens>, and replace "xxxx" with your token
-- we found that it makes our GitHub repo private by default, so we need to go to GitHub to make it public if we want to use Travis
 - we found that it gives an error in RStudio and doesn't fully enable git in RStudio, so:
 - in the shell, we need to `git remote set-url origin https://github.com/username/pkgname.git` (it does seem to work again in RStudio after completing one commit-push cycle from the shell and restarting RStudio)
 - then we can commit, push, etc. as usual, from the shell or RStudio

--- a/README.Rmd
+++ b/README.Rmd
@@ -96,7 +96,7 @@ analysis/
 - The references.bib` file is empty, ready to insert reference details
 - You can replace the supplied `csl` file with one from <https://github.com/citation-style-language/>    
 - we recommend using the [citr addin](https://github.com/crsh/citr) and [Zotero](https://www.zotero.org/) for high efficiency    
-- we need to remember that when working in the Rmd writing code, we much update DESCRIPTION Imports: with pkg names used in the Rmd
+- we need to remember that when working in the Rmd writing code, we must update DESCRIPTION Imports: with pkg names used in the Rmd
 
 #### 7. `rrtools::use_dockerfile()`           
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ To create a reproducible research compendium using the rrtools approach, follow 
 -   The references.bib\` file is empty, ready to insert reference details
 -   You can replace the supplied `csl` file with one from <https://github.com/citation-style-language/>
 -   we recommend using the [citr addin](https://github.com/crsh/citr) and [Zotero](https://www.zotero.org/) for high efficiency
--   we need to remember that when working in the Rmd writing code, we much update DESCRIPTION Imports: with pkg names used in the Rmd
+-   we need to remember that when working in the Rmd writing code, we must update DESCRIPTION Imports: with pkg names used in the Rmd
 
 #### 7. `rrtools::use_dockerfile()`
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,10 @@ To create a reproducible research compendium using the rrtools approach, follow 
 
 -   this gives MIT licence in DESCRIPTION, adds LICENSE file with our name in it
 
-#### 3. `devtools::use_github(".", auth_token = "xxxx")`
+#### 3. `devtools::use_github(".", auth_token = "xxxx", private = FALSE)`
 
 -   This will initialize a local git repository, and connect to github.com and create a remote repository there.
 -   we need to get a token from <https://github.com/settings/tokens>, and replace "xxxx" with your token
--   we found that it makes our GitHub repo private by default, so we need to go to GitHub to make it public if we want to use Travis
 -   we found that it gives an error in RStudio and doesn't fully enable git in RStudio, so:
 -   in the shell, we need to `git remote set-url origin https://github.com/username/pkgname.git` (it does seem to work again in RStudio after completing one commit-push cycle from the shell and restarting RStudio)
 -   then we can commit, push, etc. as usual, from the shell or RStudio


### PR DESCRIPTION
- a little change of a word
- i tested the `devtools::use_github` command and it actually created a public repository when stating explicitly that the repo shall not be private. Hence, I changed the comment accordingly