### PR TITLE
username for dockerhub from env. variables

### DIFF
--- a/inst/templates/travis.yml-with-docker
+++ b/inst/templates/travis.yml-with-docker
@@ -2,7 +2,7 @@
 
 env:
   global:
-  - REPO={{{username}}}/{{{repo}}}
+  - REPO=$DOCKER_USER/{{{repo}}}
 
 sudo: required
 
@@ -20,7 +20,7 @@ before_install:
 # push our custom docker container to docker hub, env vars stored on travis-ci.org
 after_success:
   - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-  - export REPO={{{username}}}/{{{repo}}}
+  - export REPO=$DOCKER_USER/{{{repo}}}
   - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
   - docker build -f Dockerfile -t $REPO:$COMMIT .
   - docker tag $REPO:$COMMIT $REPO:$TAG


### PR DESCRIPTION
With this the username for hub.docker.com is taken from the travis env variables instead of taken the github user name.

Referring to our discussion in https://github.com/benmarwick/rrtools/issues/12, this actually seems to be more elegant than entering it locally since:

* When using travis, this environmental variable must be given anyhow
* to work at all, it must be correct
* we cannot script this from within R
* less redundancy