### PR TITLE
Enabled `rrtools::use_analysis(location = "vignettes")` to set up compendium

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ Authors@R: c(person("Ben", "Marwick", role = c("aut", "cre"), email = "benmarwic
              person("Clemens", "Schmid", role = "ctb"),
              person("Ricarda", "Braun", role = "ctb"),
              person("Wojciech", "Francuzik", role = "ctb"),
-             person("Charles", "Gray", role = "ctb"))
+             person("Charles", "Gray", role = "ctb"),
+             person("Joseph de la Torre", "Dwyer", role = "ctb"))
 Maintainer: Ben Marwick <benmarwick@gmail.com>
 Description: Instructions, templates, and functions for making a basic 
     compendium suitable for doing reproducible research with R.

--- a/R/hello.R
+++ b/R/hello.R
@@ -645,7 +645,7 @@ use_paper_rmd <- function(pkg, location, gh, template){
   writeLines(rmd, file.path(pkg$path, location, "paper.Rmd"))
   closeAllConnections()
 
-
+  open_in_rstudio(paste0(pkg$path, "/", location, "/paper.Rmd"))
 }
 
 
@@ -666,10 +666,10 @@ use_vignette_rmd <- function(location, pkg, gh, template, vignette_yml = "vignet
   # we inject a bit of vignette yml in our main paper.Rmd template:
   rmd <- c(rmd[1:18], vignette_yml, rmd[19:32], paste0("\nlibrary(", pkg$package, ")"), rmd[33:length(rmd)])
   # use_template doesn't seem to work for this...
-  writeLines(rmd, file(paste0(location, "/paper/paper.Rmd")))
+  writeLines(rmd, file(paste0(pkg$path, "/", location, "/paper/paper.Rmd")))
   closeAllConnections()
 
-  open_in_rstudio(paste0(location, "/paper/paper.Rmd"))
+  open_in_rstudio(paste0(pkg$path, "/", location, "/paper/paper.Rmd"))
 }
 
 

--- a/R/infrastructure-git.R
+++ b/R/infrastructure-git.R
@@ -207,7 +207,7 @@ use_git_ignore <- function(ignores, directory = ".", pkg = ".", quiet = FALSE) {
 
   paths <- paste0("`", ignores, "`", collapse = ", ")
   if (!quiet) {
-    usethis::ui_done("Adding ", paths, " to ", file.path(directory, ".gitignore"))
+    usethis::ui_done("Adding {usethis::ui_value(paths)} to {usethis::ui_value(file.path(directory, '.gitignore'))}")
   }
 
   path <- file.path(pkg$path, directory, ".gitignore")

--- a/tests/testthat/test_use_analysis.R
+++ b/tests/testthat/test_use_analysis.R
@@ -1,6 +1,6 @@
 context("use_analysis()")
 
-#### run function ####
+#### run function default (analysis/) ####
 
 suppressMessages(
   rrtools::use_analysis(pkg = package_path)
@@ -14,6 +14,46 @@ test_that("use_analysis generates the template directories and files", {
                c("data", "figures",  "paper", "templates"))
 
   expect_equal(list.files(file.path(package_path, 'analysis', 'paper')),
+               c("paper.Rmd", "references.bib"))
+
+})
+
+
+
+#### run function inst/ ####
+
+suppressMessages(
+  rrtools::use_analysis(pkg = package_path, location = "inst")
+)
+
+#### check results ####
+
+test_that("use_analysis(location = 'inst') generates the template directories and files", {
+
+  expect_equal(list.files(file.path(package_path, 'inst')),
+               c("data", "figures",  "paper", "templates"))
+
+  expect_equal(list.files(file.path(package_path, 'inst', 'paper')),
+               c("paper.Rmd", "references.bib"))
+
+})
+
+
+
+#### run function vignettes/ ####
+
+suppressMessages(
+  rrtools::use_analysis(pkg = package_path, location = "vignettes")
+)
+
+#### check results ####
+
+test_that("use_analysis(location = 'vignettes') generates the template directories and files", {
+
+  expect_equal(list.files(file.path(package_path, 'vignettes')),
+               c("data", "figures",  "paper", "templates"))
+
+  expect_equal(list.files(file.path(package_path, 'vignettes', 'paper')),
                c("paper.Rmd", "references.bib"))
 
 })


### PR DESCRIPTION
Fixes #81 

This function failed to set up the compendium because a
`usethis::ui_done()` was malformed (a typo turned the
required 1 argument into 4 arguments).

Once this was fixed, it turned out that some
`writeLines()` functions were not pointing to the
correct path and thus failed to create `/paper.Rmd`.

Once this was fixed,
`tests/testthat/test_use_analysis.R` was extended to
test that `location = "inst"` and `location =
"vignettes"` create the proper analysis sub-directories
_and_ that `paper/` contains `paper.Rmd` and
`references.bib`.

Although `devtools::check()` completed with 0 errors,
warnings, or notes, `rrtools::use_analysis(location =
"vignettes")` still failed in the field. This was again
a path error (this time in `open_in_rstudio()`). This
was rectified and new code was added so that RStudio
opens `paper.Rmd` for the user for all three locations,
i.e., `"top_level"`, `"inst"`, and `"vignettes"`.