### PR TITLE
Explicitly install packages required in default `paper.Rmd`

### DIFF
--- a/inst/templates/paper.Rmd
+++ b/inst/templates/paper.Rmd
@@ -32,6 +32,15 @@ knitr::opts_chunk$set(
 )
 ```
 
+```{r install-and-load-packages, echo = FALSE}
+# Install all packages here that are required below
+  # install.packages("packageUsedBelow")
+install.packages(c("devtools", "git2r", "here"))
+
+# Load the above packages here or use `package::function()` in your R chunks
+  # library(packageUsedBelow)
+```
+
 # Introduction
 
 Here is a citation [@Marwick2017]


### PR DESCRIPTION
The `rocker/verse` image is not guaranteed to have `here` package installed (or `devtools` and `git2r` either) (e.g., `rocker/verse:3.5.3`), all of which are required to knit `paper.Rmd`, so I explicitly install those three packages in `paper.Rmd`.

Fixed #89 