### PR TITLE
removed empty continuation lines in Dockerfile template

### DIFF
--- a/inst/templates/Dockerfile
+++ b/inst/templates/Dockerfile
@@ -8,15 +8,12 @@ COPY . /{{{repo}}}
 
 # go into the repo directory
 RUN . /etc/environment \
-
   # Install linux depedendencies here
   # e.g. need this for ggforce::geom_sina
   && sudo apt-get update \
   && sudo apt-get install libudunits2-dev -y \
-
   # build this compendium package
   && R -e "devtools::install('/{{{repo}}}', dep=TRUE)" \
-
- # render the manuscript into a docx, you'll need to edit this if you've
- # customised the location and name of your main Rmd file
+  # render the manuscript into a docx, you'll need to edit this if you've
+  # customised the location and name of your main Rmd file
   && R -e "rmarkdown::render('/{{{repo}}}/{{{rmd_path}}}')"


### PR DESCRIPTION
I came across a warning when I tried to reproduce #89/#90 in docker version `18.09.8-ce, build 0dd43dd87f`

```
[WARNING]: Empty continuation line found in:
    RUN . /etc/environment   && sudo apt-get update   && sudo apt-get install libudunits2-dev -y   && R -e "devtools::install('/<REPO>', dep=TRUE)"   && R -e "rmarkdown::render('/<REPO>/analysis/paper/paper.Rmd')"
[WARNING]: Empty continuation lines will become errors in a future release.
```

Removing the empty lines should fix it.

**Steps to reproduce**: (stolen from @ntrlshrp)

- In R, `devtools::install_github("benmarwick/rrtools")`
- `rrtools::create_compendium("rrtoolsTEST")`
- Switch to new project/package `rrtoolsTEST`
- `rrtools::use_dockerfile()`
- Change `rocker/verse:###` to `rocker/verse:3.5.3` in `rrtoolsTEST/Dockerfile` line 1
- Switch to Terminal where current directory is `rrtoolsTEST/`
- `docker build --rm -t rrtoolstest:1.0 .` (you may need to prepend `sudo`)

