### PR TITLE
Rename setup chunk for RStudio

### DIFF
--- a/inst/templates/paper.Rmd
+++ b/inst/templates/paper.Rmd
@@ -21,7 +21,7 @@ highlights: |
 
 <!-- This is the format for text comments that will be ignored during renderings. Do not put R code in these comments because it will not be ignored. -->
 
-```{r, setup, echo = FALSE}
+```{r setup, echo = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   warning = FALSE,


### PR DESCRIPTION
:wave: Hi @benmarwick ,
Thank you so much for making `rrtools` it's an amazing tool to accelerate reproducible science.

I noticed a very small typo that prevented the first chunk in the .Rmd template to be named `setup` in the RStudio "outline bar". The trick is to remove the first comma.

It's a very small PR but I hope it helps.
Thank you again ;)