### PR TITLE
makes capitalised compendia names work with docker build tags. 

### DIFF
--- a/R/core_use_travis.R
+++ b/R/core_use_travis.R
@@ -36,6 +36,7 @@ use_travis <- function(
   gh <- github_info(pkg$path)
   gh$rmd_path <- rmd_path
   travis_url <- file.path("https://travis-ci.org", gh$fullname)
+  gh$repo <- tolower(gh$repo)
 
   if(docker){
     use_template("travis.yml-with-docker",


### PR DESCRIPTION
Small fix that addresses the problems discussed in #98. Worked for my capitalised repository.

Have a little look and let me know what you think.