### PR TITLE
Compendium creation directory logic

### DIFF
--- a/R/core_create_compendium.R
+++ b/R/core_create_compendium.R
@@ -29,4 +29,6 @@ create_compendium <- function(pkgname = getwd(),
   # install the package and its dependencies
   devtools::install(quiet = TRUE)
 
+  usethis::ui_done("The working directory is now {getwd()}")
+
 }

--- a/R/core_use_compendium.R
+++ b/R/core_use_compendium.R
@@ -125,6 +125,7 @@ use_compendium <- function(
 
     cat(crayon::bold("\nNext, you need to: "), rep(crayon::green(clisymbols::symbol$arrow_down),3), "\n")
     usethis::ui_todo("Edit the DESCRIPTION file")
+    usethis::ui_todo("Add a license file (e.g. with usethis::use_mit_license(name = 'Your Name'))")
     usethis::ui_todo("Use other 'rrtools' functions to add components to the compendium\n")
 
   })

--- a/R/core_use_compendium.R
+++ b/R/core_use_compendium.R
@@ -7,9 +7,13 @@
 #' @param path location to create new package. The last component of the path will be used as the package name
 #' @param fields list of description values to override default values or add additional values
 #' @param rstudio create an RStudio project file? (with \code{usethis::use_rstudio})
-#' @param open if TRUE and in RStudio, the new project is opened in a new instance. If TRUE and not in RStudio, the working directory is set to the new project
+#' @param open if TRUE and in RStudio, the new project is opened in a new instance.
+#' If TRUE and not in RStudio, the working directory is set to the new project
 #' @param quiet if FALSE, the default, prints informative messages
-#' @param simple if TRUE, the default, the R/ directory is not created, because it's not necessary for many if not most research repositories
+#' @param simple if TRUE, the default, the R/ directory is not created, because it's not necessary
+#' for many if not most research repositories
+#' @param welcome_message if TRUE, rstudio, open and not quiet, then the .Rprofile file in the
+#' newly created package is prepopulated with a welcome message.
 #'
 #' @importFrom usethis create_package
 #' @importFrom rstudioapi isAvailable
@@ -21,7 +25,8 @@ use_compendium <- function(
   rstudio = rstudioapi::isAvailable(),
   open = TRUE,
   quiet = FALSE,
-  simple = TRUE
+  simple = TRUE,
+  welcome_message = TRUE
 ){
 
   if (!dir.exists(path)) {
@@ -89,7 +94,7 @@ use_compendium <- function(
     check_package_name(name)
 
     # welcome message in new repo at first start
-    if (rstudio & open & !quiet) {
+    if (welcome_message & rstudio & open & !quiet) {
 
       fileConn <- file(file.path(path, ".Rprofile"))
       writeLines(

--- a/R/core_use_compendium.R
+++ b/R/core_use_compendium.R
@@ -19,7 +19,7 @@ use_compendium <- function(
   path = getwd(),
   fields = getOption("usethis.description"),
   rstudio = rstudioapi::isAvailable(),
-  open = FALSE,
+  open = TRUE,
   quiet = FALSE,
   simple = TRUE
 ){
@@ -123,6 +123,13 @@ use_compendium <- function(
 
     usethis::ui_done("The package {name} has been created")
 
+    # change working directory if not in RStudio
+    if (open & !rstudio) {
+      setwd(path)
+      usethis::ui_done("The working directory is now {getwd()}")
+    }
+
+    # ToDo messages
     cat(crayon::bold("\nNext, you need to: "), rep(crayon::green(clisymbols::symbol$arrow_down),3), "\n")
     usethis::ui_todo("Edit the DESCRIPTION file")
     usethis::ui_todo("Add a license file (e.g. with usethis::use_mit_license(name = 'Your Name'))")

--- a/man/create_compendium.Rd
+++ b/man/create_compendium.Rd
@@ -4,12 +4,23 @@
 \alias{create_compendium}
 \title{Quickly create a basic research compendium by combining several rrtools functions into one.}
 \usage{
-create_compendium(pkgname = getwd(), data_in_git = TRUE, simple = TRUE)
+create_compendium(
+  pkgname = getwd(),
+  data_in_git = TRUE,
+  rstudio = rstudioapi::isAvailable(),
+  open = TRUE,
+  simple = TRUE
+)
 }
 \arguments{
 \item{pkgname}{path to an empty, git initialized directory. The last component of the path will be used as the package name. Default is the current directory name.}
 
 \item{data_in_git}{should git track the files in the data directory? Default is TRUE}
+
+\item{rstudio}{create an RStudio project file? (with \code{usethis::use_rstudio})}
+
+\item{open}{if TRUE and in RStudio, the new project is opened in a new instance.
+If TRUE and not in RStudio, the working directory is set to the new project}
 
 \item{simple}{if TRUE, the default, the R/ directory is not created, because it's not necessary for many if not most research repositories}
 }

--- a/man/use_compendium.Rd
+++ b/man/use_compendium.Rd
@@ -9,7 +9,7 @@ use_compendium(
   path = getwd(),
   fields = getOption("usethis.description"),
   rstudio = rstudioapi::isAvailable(),
-  open = FALSE,
+  open = TRUE,
   quiet = FALSE,
   simple = TRUE
 )

--- a/man/use_compendium.Rd
+++ b/man/use_compendium.Rd
@@ -11,7 +11,8 @@ use_compendium(
   rstudio = rstudioapi::isAvailable(),
   open = TRUE,
   quiet = FALSE,
-  simple = TRUE
+  simple = TRUE,
+  welcome_message = TRUE
 )
 }
 \arguments{
@@ -21,11 +22,16 @@ use_compendium(
 
 \item{rstudio}{create an RStudio project file? (with \code{usethis::use_rstudio})}
 
-\item{open}{if TRUE and in RStudio, the new project is opened in a new instance. If TRUE and not in RStudio, the working directory is set to the new project}
+\item{open}{if TRUE and in RStudio, the new project is opened in a new instance.
+If TRUE and not in RStudio, the working directory is set to the new project}
 
 \item{quiet}{if FALSE, the default, prints informative messages}
 
-\item{simple}{if TRUE, the default, the R/ directory is not created, because it's not necessary for many if not most research repositories}
+\item{simple}{if TRUE, the default, the R/ directory is not created, because it's not necessary
+for many if not most research repositories}
+
+\item{welcome_message}{if TRUE, rstudio, open and not quiet, then the .Rprofile file in the
+newly created package is prepopulated with a welcome message.}
 }
 \description{
 This is usethis::create_package() with some additional messages to simplify the transition into the new project setting


### PR DESCRIPTION
I thought again about the directory changing logic and defaults in `use_compendium()` and `create_compendium()`. What I implemented now:

- `use_compendium()` in RStudio: Creates the repo and opens a new RStudio window in the respective directory.
- `use_compendium()` without RStudio: Creates the repo and switches the working directory to this new place.
- `create_compendium()` in RStudio:  Creates the repo, opens a new RStudio window and runs the additional commands there.
- `create_compendium()` without RStudio: Creates the repo, switches the working directory, runs the additional commands right away.